### PR TITLE
Convert auth tokens on defined NSOperationQueues

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/OAuth/DBSDKKeychain.m
@@ -174,7 +174,7 @@ static const char *kV1OSXAccountName = "Dropbox";
 #endif
 
     if ([v1TokensData count] > 0) {
-      [[NSOperationQueue new] addOperationWithBlock:^{
+      [[self v1TokenConversionOperationQueue] addOperationWithBlock:^{
         [[self class] convertV1TokenToV2:v1TokensData
                                   appKey:appKey
                                appSecret:appSecret
@@ -430,7 +430,7 @@ static const char *kV1OSXAccountName = "Dropbox";
           }
           dispatch_group_leave(tokenConvertGroup);
         }
-                   queue:[NSOperationQueue new]];
+                   queue:[self rpcTaskOperationQueue]];
   }
 
   // wait for all token conversion calls to complete and then update the keychain, and call the response block
@@ -447,6 +447,32 @@ static const char *kV1OSXAccountName = "Dropbox";
       responseBlock(shouldRetry, invalidAppKeyOrSecret, unsuccessfullyMigratedTokenData);
     }];
   });
+}
+
+#pragma mark - Operation Queues
+
+static NSOperationQueue *_v1TokenConversionOperationQueue = nil;
++ (NSOperationQueue *)v1TokenConversionOperationQueue {
+    static dispatch_once_t tokenConversionOnceToken;
+    dispatch_once(&tokenConversionOnceToken, ^{
+        _v1TokenConversionOperationQueue = [[NSOperationQueue alloc] init];
+        _v1TokenConversionOperationQueue.name = [NSString stringWithFormat:@"%@ %@", NSStringFromClass(self.class), NSStringFromSelector(_cmd)];
+        _v1TokenConversionOperationQueue.qualityOfService = NSQualityOfServiceUtility;
+    });
+
+    return _v1TokenConversionOperationQueue;
+}
+
+static NSOperationQueue *_rpcTaskOperationQueue = nil;
++ (NSOperationQueue *)rpcTaskOperationQueue {
+    static dispatch_once_t rpcTaskOnceToken;
+    dispatch_once(&rpcTaskOnceToken, ^{
+        _rpcTaskOperationQueue = [[NSOperationQueue alloc] init];
+        _rpcTaskOperationQueue.name = [NSString stringWithFormat:@"%@ %@", NSStringFromClass(self.class), NSStringFromSelector(_cmd)];
+        _rpcTaskOperationQueue.qualityOfService = NSQualityOfServiceUtility;
+    });
+
+    return _rpcTaskOperationQueue;
 }
 
 @end


### PR DESCRIPTION
Prior to this change the token conversion was spawning a new unowned operation queue for each conversion and each token RPC task. While this worked, the behavior of creating operation queues in this manner is undefined.