### PR TITLE
Don’t dismiss unpresented view controllers

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
+++ b/Source/ObjectiveDropboxOfficial/Platform/ObjectiveDropboxOfficial_iOS/DBOAuthMobile-iOS.m
@@ -110,8 +110,10 @@ static DBMobileSharedApplication *s_mobileSharedApplication;
 }
 
 - (void)dismissAuthController {
-  if (_controller) {
-    [_controller dismissViewControllerAnimated:YES completion:nil];
+  if (_controller != nil) {
+    if (_controller.presentedViewController != nil && _controller.presentedViewController.isBeingDismissed == NO && [_controller.presentedViewController isKindOfClass:[DBMobileSafariViewController class]]) {
+      [_controller dismissViewControllerAnimated:YES completion:nil];
+    }
   }
 }
 


### PR DESCRIPTION
When using the Dropbox app to authorize access, the in-app auth view is not being presented. However, when we return to the app it was indiscriminately dismissing any presented view controllers it had. In the case of 1Password, this was a view controller we were presenting to setup Dropbox sync. Additionally, in certain other cases it was over-dismissing the presented view controller, resulting in more than one view controller being dismissed.