### PR TITLE
Rework the DBDelegate implementation to use ObjC properties

### DIFF
--- a/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBDelegate.m
+++ b/Source/ObjectiveDropboxOfficial/Shared/Handwritten/Networking/DBDelegate.m
@@ -8,18 +8,23 @@
 
 #pragma mark - Initializers
 
-@implementation DBDelegate {
-  NSOperationQueue *_delegateQueue;
-  NSMutableDictionary<NSString *, DBSessionData *> *_sessionData;
-}
+@interface DBDelegate ()
+
+@property NSOperationQueue *delegateQueue;
+@property NSMutableDictionary<NSString *, DBSessionData *> *sessionData;
+
+@end
+
+@implementation DBDelegate
 
 - (instancetype)initWithQueue:(NSOperationQueue *)delegateQueue {
   self = [super init];
   if (self) {
     _delegateQueue = delegateQueue ?: [NSOperationQueue new];
     [_delegateQueue setMaxConcurrentOperationCount:1];
-    _sessionData = [NSMutableDictionary new];
+    _sessionData = [[NSMutableDictionary alloc] init];
   }
+
   return self;
 }
 
@@ -207,7 +212,7 @@
                    session:(NSURLSession *)session
            progressHandler:(void (^)(int64_t, int64_t, int64_t))handler
       progressHandlerQueue:(NSOperationQueue *)handlerQueue {
-  [_delegateQueue addOperationWithBlock:^{
+  [self.delegateQueue addOperationWithBlock:^{
     NSNumber *taskId = @(task.taskIdentifier);
 
     DBSessionData *sessionData = [self sessionDataWithSession:session];
@@ -234,7 +239,7 @@
                       session:(NSURLSession *)session
               responseHandler:(DBRpcResponseBlockStorage)handler
          responseHandlerQueue:(NSOperationQueue *)handlerQueue {
-  [_delegateQueue addOperationWithBlock:^{
+  [self.delegateQueue addOperationWithBlock:^{
     NSNumber *taskId = @(task.taskIdentifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
@@ -266,7 +271,7 @@
                          session:(NSURLSession *)session
                  responseHandler:(DBUploadResponseBlockStorage)handler
             responseHandlerQueue:(NSOperationQueue *)handlerQueue {
-  [_delegateQueue addOperationWithBlock:^{
+  [self.delegateQueue addOperationWithBlock:^{
     NSNumber *taskId = @(task.taskIdentifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
@@ -298,7 +303,7 @@
                            session:(NSURLSession *)session
                    responseHandler:(DBDownloadResponseBlockStorage)handler
               responseHandlerQueue:(NSOperationQueue *)handlerQueue {
-  [_delegateQueue addOperationWithBlock:^{
+  [self.delegateQueue addOperationWithBlock:^{
     NSNumber *taskId = @(task.taskIdentifier);
     DBSessionData *sessionData = [self sessionDataWithSession:session];
 
@@ -330,10 +335,15 @@
 
 - (DBSessionData *)sessionDataWithSession:(NSURLSession *)session {
   NSString *sessionId = [self sessionIdWithSession:session];
-  if (!_sessionData[sessionId]) {
-    _sessionData[sessionId] = [[DBSessionData alloc] initWithSessionId:sessionId];
+  DBSessionData *sessionData = self.sessionData[sessionId];
+  if (sessionData == nil) {
+    sessionData = [[DBSessionData alloc] initWithSessionId:sessionId];
+    if (sessionData != nil) {
+      self.sessionData[sessionId] = sessionData;
+    }
   }
-  return _sessionData[sessionId];
+
+  return sessionData;
 }
 
 @end


### PR DESCRIPTION
We're getting crashes in 1Password with the following backtrace hits:

```objective-c
Incident Identifier: 8BE586D6-F587-4A20-B96A-9C1B5100534C
CrashReporter Key:   95FB86FB-D31E-43AE-9996-2362BEDADC83
Hardware Model:      iPhone7,1
Process:         1Password [1511]
Path:            /var/containers/Bundle/Application/53A3C1E7-672E-4742-9A7D-DB672FBB4998/1Password.app/1Password
Identifier:      com.agilebits.onepassword-ios
Version:         7.2.1 (70201002)
Code Type:       ARM-64
Parent Process:  ??? [1]

Date/Time:       2018-10-11T02:44:50Z
Launch Time:     2018-10-11T02:44:42Z
OS Version:      iPhone OS 12.0.1 (16A404)
Report Version:  104

Exception Type:  SIGSEGV
Exception Codes: SEGV_ACCERR at 0x0
Crashed Thread:  6

Application Specific Information:
Selector name found in current argument registers: hash

.
.
.

Thread 6 Crashed:
0   CoreFoundation                       0x00000001bd1d7010 -[__NSDictionaryM setObject:forKeyedSubscript:] + 484
1   ObjectiveDropboxOfficial             0x0000000101790050 -[DBDelegate sessionDataWithSession:] (DBDelegate.m:334)
2   ObjectiveDropboxOfficial             0x000000010178eeb0 __81-[DBDelegate addRpcResponseHandler:session:responseHandler:responseHandlerQueue:]_block_invoke (DBDelegate.m:239)
3   Foundation                           0x00000001bdd73b6c __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ + 12
4   Foundation                           0x00000001bdc7bcc8 -[NSBlockOperation main] + 68
5   Foundation                           0x00000001bdc7b19c -[__NSOperationInternal _start:] + 736
6   Foundation                           0x00000001bdd75a40 __NSOQSchedule_f + 268
7   libdispatch.dylib                    0x00000001bcd1f6c8 _dispatch_call_block_and_release + 20
8   libdispatch.dylib                    0x00000001bcd20484 _dispatch_client_callout + 12
9   libdispatch.dylib                    0x00000001bccc3874 _dispatch_continuation_pop$VARIANT$mp + 408
10  libdispatch.dylib                    0x00000001bccc2f3c _dispatch_async_redirect_invoke + 596
11  libdispatch.dylib                    0x00000001bcccfa60 _dispatch_root_queue_drain + 372
12  libdispatch.dylib                    0x00000001bccd0308 _dispatch_worker_thread2 + 124
13  libsystem_pthread.dylib              0x00000001bcf02190 _pthread_wqthread + 468
14  libsystem_pthread.dylib              0x00000001bcf04d00 start_wqthread + 0
```

This PR starts with some small cosmetic and safety changes.